### PR TITLE
Allow user to set the project dir

### DIFF
--- a/Kernel.php
+++ b/Kernel.php
@@ -83,12 +83,23 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     const END_OF_MAINTENANCE = '01/2020';
     const END_OF_LIFE = '07/2020';
 
-    public function __construct(string $environment, bool $debug)
+    public function __construct(string $environment, bool $debug, string $projectDir = null)
     {
         $this->environment = $environment;
         $this->debug = $debug;
         $this->rootDir = $this->getRootDir(false);
         $this->name = $this->getName(false);
+        if (null !== $projectDir && !is_dir($projectDir)) {
+            $backtrace = debug_backtrace();
+            $caller = array_shift($backtrace);
+            throw new \InvalidArgumentException(sprintf(
+                'Directory "%s" is not a directory, so it can not be used at project directory. Update the path in %s (line %d)',
+                $projectDir,
+                $caller['file'],
+                $caller['line']
+            ));
+        }
+        $this->projectDir = $projectDir;
     }
 
     public function __clone()


### PR DESCRIPTION
Currently, the project directory is defined by the location of the composer.json file.

That file is not required in production, which therefore [breaks the method getProjectDir](https://github.com/symfony/symfony/issues/23950) (who sends back null).
The offered solution, while working, requires the developer to implement it, and uses inheritance override, while a more aesthetic solution could be used.

This does not fix the behaviour, but allows the developer to pass the project dir as a parameter.

While this solution does not include BC break or anything, it is important to notice that it includes
**an optional parameter**.

[Object instantiation in the framework bundle recipe](https://github.com/symfony/recipes/blob/master/symfony/framework-bundle/4.2/public/index.php#L23) could be updated as follow (in another PR):

```php
$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
```

```php
$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG'], dirname(__DIR__));
```